### PR TITLE
fix domain name from api.jpx-jquants.com to api.jquants.com

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-const BASE_URL = "https://api.jpx-jquants.com/v1"
+const BASE_URL = "https://api.jquants.com/v1"
 const REFRESH_TOKEN_FILE = "refresh_token.edn"
 const ID_TOKEN_FILE = "id_token.edn"
 


### PR DESCRIPTION
fix #1 

Modified with reference to [Refresh Token (/token/auth_user) - j-quants(English)](https://jpx.gitbook.io/j-quants-en/api-reference/refreshtoken).